### PR TITLE
Modify private method

### DIFF
--- a/crawler_py/crawler.py
+++ b/crawler_py/crawler.py
@@ -44,11 +44,8 @@ class WikipediaCrawler:
 
         return None
 
-    def _get_linked_titles(self, title: str) -> set[str]:
-        html = requests.get(f"{GET_HTML_URL}/{title}", timeout=5).text
-        return self._linked_titles_in_html(html)
-
-    def _linked_titles_in_html(self, html: str) -> set[str]:
+    @staticmethod
+    def linked_titles_in_html(html: str) -> set[str]:
         all_links = BeautifulSoup(html, "html.parser").find_all("a")
 
         linked_titles: set[str] = set()
@@ -60,6 +57,10 @@ class WikipediaCrawler:
                 linked_titles.add(linked_title)
 
         return linked_titles
+
+    def _get_linked_titles(self, title: str) -> set[str]:
+        html = requests.get(f"{GET_HTML_URL}/{title}", timeout=5).text
+        return self.linked_titles_in_html(html)
 
     def _get_path(
         self,

--- a/crawler_rs/src/lib.rs
+++ b/crawler_rs/src/lib.rs
@@ -33,7 +33,7 @@ impl WikipediaCrawler {
         let mut visited_pages = 0;
 
         while let Some(cur_title) = queue.pop_front() {
-            println!("visited {} pages", visited_pages);
+            println!("visited {visited_pages} pages");
 
             let linked_titles = self.get_linked_titles(&cur_title).await?;
 

--- a/crawler_rs/src/lib.rs
+++ b/crawler_rs/src/lib.rs
@@ -58,13 +58,7 @@ impl WikipediaCrawler {
         Err(anyhow::Error::msg("Could not find path to Kevin Bacon"))
     }
 
-    async fn get_linked_titles(&self, title: &str) -> reqwest::Result<HashSet<String>> {
-        let url = format!("{GET_HTML_URL}/{title}");
-        let html = reqwest::get(url).await?.text().await?;
-        Ok(self.linked_titles_in_html(&html))
-    }
-
-    fn linked_titles_in_html(&self, html: &str) -> HashSet<String> {
+    pub fn linked_titles_in_html(html: &str) -> HashSet<String> {
         let parsed = scraper::Html::parse_document(html);
         let selector = Selector::parse("a").expect("Should be able to parse `a` elements");
         let all_links = parsed.select(&selector);
@@ -80,6 +74,12 @@ impl WikipediaCrawler {
         }
 
         linked_titles
+    }
+
+    async fn get_linked_titles(&self, title: &str) -> reqwest::Result<HashSet<String>> {
+        let url = format!("{GET_HTML_URL}/{title}");
+        let html = reqwest::get(url).await?.text().await?;
+        Ok(Self::linked_titles_in_html(&html))
     }
 
     fn get_path(&self, parents: &HashMap<String, String>) -> anyhow::Result<Vec<String>> {
@@ -99,185 +99,5 @@ impl WikipediaCrawler {
 
         path.reverse();
         Ok(path)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    // const FOOTLOOSE_TITLE: &str = "Footloose_(1984_film)";
-    // const HERBERT_ROSS_TITLE: &str = "Herbert_Ross";
-    // const FRIDAY_THE_13TH_TITLE: &str = "Friday_the_13th_(1980_film)";
-    // const CITY_ON_A_HILL: &str = "City_on_a_Hill_(TV_series)";
-    // const AMANDA_CLAYTON_TITLE: &str = "Amanda_Clayton";
-    // const THE_BET_TITLE: &str = "The_Bet_(2016_film)";
-    //
-    // #[tokio::test]
-    // async fn starting_at_kevin_bacon() {
-    //     let mut crawler = WikipediaCrawler::new(KEVIN_BACON_TITLE);
-    //     assert_eq!(crawler.crawl().await.unwrap(), vec![KEVIN_BACON_TITLE]);
-    // }
-    //
-    // #[tokio::test]
-    // async fn one_hop_1() {
-    //     let mut crawler = WikipediaCrawler::new(FOOTLOOSE_TITLE);
-    //     assert_eq!(
-    //         crawler.crawl().await.unwrap(),
-    //         vec![FOOTLOOSE_TITLE, KEVIN_BACON_TITLE]
-    //     );
-    // }
-    //
-    // #[tokio::test]
-    // async fn one_hop_2() {
-    //     let mut crawler = WikipediaCrawler::new(FRIDAY_THE_13TH_TITLE);
-    //     assert_eq!(
-    //         crawler.crawl().await.unwrap(),
-    //         vec![FRIDAY_THE_13TH_TITLE, KEVIN_BACON_TITLE]
-    //     );
-    // }
-    //
-    // #[tokio::test]
-    // async fn one_hop_3() {
-    //     let mut crawler = WikipediaCrawler::new(CITY_ON_A_HILL);
-    //     assert_eq!(
-    //         crawler.crawl().await.unwrap(),
-    //         vec![CITY_ON_A_HILL, KEVIN_BACON_TITLE]
-    //     );
-    // }
-    //
-    // #[ignore]
-    // #[tokio::test]
-    // async fn two_hops_1() {
-    //     // Runs in about 5-60 seconds
-    //     // Multiple paths with two hops
-    //     let mut crawler = WikipediaCrawler::new(HERBERT_ROSS_TITLE);
-    //     let result = crawler.crawl().await.unwrap();
-    //
-    //     assert_eq!(result.len(), 3);
-    //     assert_eq!(result.first().unwrap(), HERBERT_ROSS_TITLE);
-    //     assert_eq!(result.last().unwrap(), KEVIN_BACON_TITLE);
-    // }
-    //
-    // #[ignore]
-    // #[tokio::test]
-    // async fn two_hops_2() {
-    //     // Runs in about 5-20 seconds
-    //     let mut crawler = WikipediaCrawler::new(AMANDA_CLAYTON_TITLE);
-    //     assert_eq!(
-    //         crawler.crawl().await.unwrap(),
-    //         vec![AMANDA_CLAYTON_TITLE, CITY_ON_A_HILL, KEVIN_BACON_TITLE]
-    //     );
-    // }
-    //
-    // #[ignore]
-    // #[tokio::test]
-    // async fn three_hops() {
-    //     // Runs in about 1-7 minutes
-    //     let mut crawler = WikipediaCrawler::new(THE_BET_TITLE);
-    //     let result = crawler.crawl().await.unwrap();
-    //
-    //     assert_eq!(result.len(), 4);
-    //     assert_eq!(result.first().unwrap(), THE_BET_TITLE);
-    //     assert_eq!(result.last().unwrap(), KEVIN_BACON_TITLE);
-    // }
-    //
-    #[tokio::test]
-    async fn get_links_in_sample_html() {
-        let html = r#"
-      <p id="mwEA">
-        He is known for directing musical and comedies such as
-        <i id="mwEQ">
-            <a href="./Goodbye,_Mr._Chips_(1969_film)" id="mwEg" rel="mw:WikiLink" title="Goodbye, Mr. Chips (1969 film)">
-            Goodbye, Mr. Chips
-            </a>
-        </i>
-        (1969),
-        <i id="mwEw">
-            <a href="./The_Owl_and_the_Pussycat_(film)" id="mwFA" rel="mw:WikiLink" title="The Owl and the Pussycat (film)">
-            The Owl and the Pussycat
-            </a>
-        </i>
-        (1970),
-        <i id="mwFQ">
-            <a href="./Play_It_Again,_Sam_(film)" id="mwFg" rel="mw:WikiLink" title="Play It Again, Sam (film)">
-            Play It Again, Sam
-            </a>
-        </i>
-        (1972),
-        <i id="mwFw">
-            <a href="./The_Sunshine_Boys_(1975_film)" id="mwGA" rel="mw:WikiLink" title="The Sunshine Boys (1975 film)">
-            The Sunshine Boys
-            </a>
-        </i>
-        ,
-        <i id="mwGQ">
-            <a href="./Funny_Lady" id="mwGg" rel="mw:WikiLink" title="Funny Lady">
-            Funny Lady
-            </a>
-        </i>
-        (both 1975),
-        <i id="mwGw">
-            <a href="./The_Goodbye_Girl" id="mwHA" rel="mw:WikiLink" title="The Goodbye Girl">
-            The Goodbye Girl
-            </a>
-        </i>
-        (1977),
-        <i id="mwHQ">
-            <a href="./California_Suite_(film)" id="mwHg" rel="mw:WikiLink" title="California Suite (film)">
-            California Suite
-            </a>
-        </i>
-        (1978), and
-        <i id="mwHw">
-            <a href="./Pennies_from_Heaven_(1981_film)" id="mwIA" rel="mw:WikiLink" title="Pennies from Heaven (1981 film)">
-            Pennies From Heaven
-            </a>
-        </i>
-        (1981). His later films include
-        <i id="mwIQ">
-            <a href="./Footloose_(1984_film)" id="mwIg" rel="mw:WikiLink" title="Footloose (1984 film)">
-            Footloose
-            </a>
-        </i>
-        (1984), and
-        <i id="mwIw">
-            <a href="./Steel_Magnolias" id="mwJA" rel="mw:WikiLink" title="Steel Magnolias">
-            Steel Magnolias
-            </a>
-        </i>
-        (1989). For the drama
-        <i id="mwJQ">
-            <a href="./The_Turning_Point_(1977_film)" id="mwJg" rel="mw:WikiLink" title="The Turning Point (1977 film)">
-            The Turning Point
-            </a>
-        </i>
-        (1977) he received two
-        <a class="mw-redirect" href="./Academy_Award" id="mwJw" rel="mw:WikiLink" title="Academy Award">
-            Academy Award
-        </a>
-        .
-      </p>"#;
-        assert_eq!(
-            WikipediaCrawler::new("").linked_titles_in_html(html),
-            HashSet::from_iter(
-                [
-                    "Goodbye,_Mr._Chips_(1969_film)",
-                    "The_Owl_and_the_Pussycat_(film)",
-                    "Play_It_Again,_Sam_(film)",
-                    "The_Sunshine_Boys_(1975_film)",
-                    "Funny_Lady",
-                    "The_Goodbye_Girl",
-                    "California_Suite_(film)",
-                    "Pennies_from_Heaven_(1981_film)",
-                    "Footloose_(1984_film)",
-                    "Steel_Magnolias",
-                    "The_Turning_Point_(1977_film)",
-                    "Academy_Award",
-                ]
-                .map(String::from)
-                .into_iter()
-            )
-        );
     }
 }

--- a/server_rs/src/main.rs
+++ b/server_rs/src/main.rs
@@ -25,7 +25,7 @@ async fn main() {
     let host = ["127.0.0.1", &port].join(":");
     let listener = tokio::net::TcpListener::bind(&host).await.unwrap();
 
-    println!("Server running on port: {}", port);
+    println!("Server running on port: {port}");
     axum::serve(listener, app).await.unwrap();
 }
 

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -135,7 +135,7 @@ def test_get_links_in_sample_html():
     .
 </p>
 """
-    assert WikipediaCrawler("")._linked_titles_in_html(html) == set(
+    assert WikipediaCrawler.linked_titles_in_html(html) == set(
         [
             "Goodbye,_Mr._Chips_(1969_film)",
             "The_Owl_and_the_Pussycat_(film)",

--- a/tests/test_crawler.rs
+++ b/tests/test_crawler.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use crawler_rs::{KEVIN_BACON_TITLE, WikipediaCrawler};
 
 const FOOTLOOSE_TITLE: &str = "Footloose_(1984_film)";
@@ -74,4 +76,103 @@ async fn three_hops() {
     assert_eq!(result.len(), 4);
     assert_eq!(result.first().unwrap(), THE_BET_TITLE);
     assert_eq!(result.last().unwrap(), KEVIN_BACON_TITLE);
+}
+
+#[tokio::test]
+async fn get_links_in_sample_html() {
+    let html = r#"
+      <p id="mwEA">
+        He is known for directing musical and comedies such as
+        <i id="mwEQ">
+            <a href="./Goodbye,_Mr._Chips_(1969_film)" id="mwEg" rel="mw:WikiLink" title="Goodbye, Mr. Chips (1969 film)">
+            Goodbye, Mr. Chips
+            </a>
+        </i>
+        (1969),
+        <i id="mwEw">
+            <a href="./The_Owl_and_the_Pussycat_(film)" id="mwFA" rel="mw:WikiLink" title="The Owl and the Pussycat (film)">
+            The Owl and the Pussycat
+            </a>
+        </i>
+        (1970),
+        <i id="mwFQ">
+            <a href="./Play_It_Again,_Sam_(film)" id="mwFg" rel="mw:WikiLink" title="Play It Again, Sam (film)">
+            Play It Again, Sam
+            </a>
+        </i>
+        (1972),
+        <i id="mwFw">
+            <a href="./The_Sunshine_Boys_(1975_film)" id="mwGA" rel="mw:WikiLink" title="The Sunshine Boys (1975 film)">
+            The Sunshine Boys
+            </a>
+        </i>
+        ,
+        <i id="mwGQ">
+            <a href="./Funny_Lady" id="mwGg" rel="mw:WikiLink" title="Funny Lady">
+            Funny Lady
+            </a>
+        </i>
+        (both 1975),
+        <i id="mwGw">
+            <a href="./The_Goodbye_Girl" id="mwHA" rel="mw:WikiLink" title="The Goodbye Girl">
+            The Goodbye Girl
+            </a>
+        </i>
+        (1977),
+        <i id="mwHQ">
+            <a href="./California_Suite_(film)" id="mwHg" rel="mw:WikiLink" title="California Suite (film)">
+            California Suite
+            </a>
+        </i>
+        (1978), and
+        <i id="mwHw">
+            <a href="./Pennies_from_Heaven_(1981_film)" id="mwIA" rel="mw:WikiLink" title="Pennies from Heaven (1981 film)">
+            Pennies From Heaven
+            </a>
+        </i>
+        (1981). His later films include
+        <i id="mwIQ">
+            <a href="./Footloose_(1984_film)" id="mwIg" rel="mw:WikiLink" title="Footloose (1984 film)">
+            Footloose
+            </a>
+        </i>
+        (1984), and
+        <i id="mwIw">
+            <a href="./Steel_Magnolias" id="mwJA" rel="mw:WikiLink" title="Steel Magnolias">
+            Steel Magnolias
+            </a>
+        </i>
+        (1989). For the drama
+        <i id="mwJQ">
+            <a href="./The_Turning_Point_(1977_film)" id="mwJg" rel="mw:WikiLink" title="The Turning Point (1977 film)">
+            The Turning Point
+            </a>
+        </i>
+        (1977) he received two
+        <a class="mw-redirect" href="./Academy_Award" id="mwJw" rel="mw:WikiLink" title="Academy Award">
+            Academy Award
+        </a>
+        .
+      </p>"#;
+    assert_eq!(
+        WikipediaCrawler::linked_titles_in_html(html),
+        HashSet::from_iter(
+            [
+                "Goodbye,_Mr._Chips_(1969_film)",
+                "The_Owl_and_the_Pussycat_(film)",
+                "Play_It_Again,_Sam_(film)",
+                "The_Sunshine_Boys_(1975_film)",
+                "Funny_Lady",
+                "The_Goodbye_Girl",
+                "California_Suite_(film)",
+                "Pennies_from_Heaven_(1981_film)",
+                "Footloose_(1984_film)",
+                "Steel_Magnolias",
+                "The_Turning_Point_(1977_film)",
+                "Academy_Award",
+            ]
+            .map(String::from)
+            .into_iter()
+        )
+    );
 }


### PR DESCRIPTION
Make the private method `linked_titles_in_html` into a public associated
function / static method. `self` is not used, and it acts as a related utility function.

Move the function's unit tests into the shared `tests` directory with the
rest of the crawler tests.