### PR TITLE
Use shared titles in code and test files

### DIFF
--- a/crawlers/crawler_py/crawler.py
+++ b/crawlers/crawler_py/crawler.py
@@ -2,9 +2,9 @@ from collections import deque
 import re
 import requests
 from bs4 import BeautifulSoup, Tag
+from titles.titles import KEVIN_BACON
 
 GET_HTML_URL = "https://en.wikipedia.org/api/rest_v1/page/html"
-KEVIN_BACON_TITLE = "Kevin_Bacon"
 # The returned html links to other articles by relative paths to their title
 ARTICLE_LINK_PREFIX = "./"
 
@@ -17,8 +17,8 @@ class WikipediaCrawler:
         self.start: str = starting_page_title
 
     def crawl(self) -> list[str] | None:
-        if self.start == KEVIN_BACON_TITLE:
-            return [KEVIN_BACON_TITLE]
+        if self.start == KEVIN_BACON:
+            return [KEVIN_BACON]
 
         queue = deque([self.start])
         parents: dict[str, str] = {}
@@ -37,7 +37,7 @@ class WikipediaCrawler:
 
                 parents[linked_title] = cur_title
 
-                if linked_title == KEVIN_BACON_TITLE:
+                if linked_title == KEVIN_BACON:
                     return self._get_path(parents)
 
                 queue.append(linked_title)
@@ -68,7 +68,7 @@ class WikipediaCrawler:
         return self.linked_titles_in_html(html)
 
     def _get_path(self, parents: dict[str, str]) -> list[str]:
-        path = [KEVIN_BACON_TITLE]
+        path = [KEVIN_BACON]
 
         while path[-1] != self.start:
             parent = parents[path[-1]]

--- a/crawlers/crawler_py/test_crawler.py
+++ b/crawlers/crawler_py/test_crawler.py
@@ -1,62 +1,64 @@
 import pytest
-from crawlers.crawler_py.crawler import WikipediaCrawler, KEVIN_BACON_TITLE
-
-FOOTLOOSE_TITLE = "Footloose_(1984_film)"
-HERBERT_ROSS_TITLE = "Herbert_Ross"
-FRIDAY_THE_13TH_TITLE = "Friday_the_13th_(1980_film)"
-CITY_ON_A_HILL = "City_on_a_Hill_(TV_series)"
-AMANDA_CLAYTON_TITLE = "Amanda_Clayton"
-THE_BET_TITLE = "The_Bet_(2016_film)"
+from crawlers.crawler_py.crawler import WikipediaCrawler
+from titles.titles import (
+    KEVIN_BACON,
+    FOOTLOOSE,
+    HERBERT_ROSS,
+    FRIDAY_THE_13TH,
+    CITY_ON_A_HILL,
+    AMANDA_CLAYTON,
+    THE_BET,
+)
 
 
 def test_starting_at_kevin_bacon():
-    crawler = WikipediaCrawler(KEVIN_BACON_TITLE)
-    assert crawler.crawl() == [KEVIN_BACON_TITLE]
+    crawler = WikipediaCrawler(KEVIN_BACON)
+    assert crawler.crawl() == [KEVIN_BACON]
 
 
 def test_one_hop_1():
-    crawler = WikipediaCrawler(FOOTLOOSE_TITLE)
-    assert crawler.crawl() == [FOOTLOOSE_TITLE, KEVIN_BACON_TITLE]
+    crawler = WikipediaCrawler(FOOTLOOSE)
+    assert crawler.crawl() == [FOOTLOOSE, KEVIN_BACON]
 
 
 def test_one_hop_2():
-    crawler = WikipediaCrawler(FRIDAY_THE_13TH_TITLE)
-    assert crawler.crawl() == [FRIDAY_THE_13TH_TITLE, KEVIN_BACON_TITLE]
+    crawler = WikipediaCrawler(FRIDAY_THE_13TH)
+    assert crawler.crawl() == [FRIDAY_THE_13TH, KEVIN_BACON]
 
 
 def test_one_hop_3():
     crawler = WikipediaCrawler(CITY_ON_A_HILL)
-    assert crawler.crawl() == [CITY_ON_A_HILL, KEVIN_BACON_TITLE]
+    assert crawler.crawl() == [CITY_ON_A_HILL, KEVIN_BACON]
 
 
 @pytest.mark.skip
 def test_two_hops_1():
     # Runs in about 10 seconds
     # Multiple paths with two hops
-    crawler = WikipediaCrawler(HERBERT_ROSS_TITLE)
+    crawler = WikipediaCrawler(HERBERT_ROSS)
     result = crawler.crawl()
     assert result is not None
     assert len(result) == 3
-    assert result[0] == HERBERT_ROSS_TITLE
-    assert result[2] == KEVIN_BACON_TITLE
+    assert result[0] == HERBERT_ROSS
+    assert result[2] == KEVIN_BACON
 
 
 @pytest.mark.skip
 def test_two_hops_2():
     # Runs in about 10 seconds
-    crawler = WikipediaCrawler(AMANDA_CLAYTON_TITLE)
-    assert crawler.crawl() == [AMANDA_CLAYTON_TITLE, CITY_ON_A_HILL, KEVIN_BACON_TITLE]
+    crawler = WikipediaCrawler(AMANDA_CLAYTON)
+    assert crawler.crawl() == [AMANDA_CLAYTON, CITY_ON_A_HILL, KEVIN_BACON]
 
 
 @pytest.mark.skip
 def test_three_hops():
     # Runs in about 10 minutes
-    crawler = WikipediaCrawler(THE_BET_TITLE)
+    crawler = WikipediaCrawler(THE_BET)
     result = crawler.crawl()
     assert result is not None
     assert len(result) == 4
-    assert result[0] == THE_BET_TITLE
-    assert result[3] == KEVIN_BACON_TITLE
+    assert result[0] == THE_BET
+    assert result[3] == KEVIN_BACON
 
 
 def test_get_links_in_sample_html():

--- a/crawlers/crawler_rs/Cargo.toml
+++ b/crawlers/crawler_rs/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 anyhow = "1.0.86"
 reqwest = { version = "0.12.4", features = ["blocking"] }
 scraper = "0.19.0"
+titles = { path = "../../titles/" }
 
 [lints.clippy]
 pedantic = "warn"

--- a/crawlers/crawler_rs/src/lib.rs
+++ b/crawlers/crawler_rs/src/lib.rs
@@ -1,9 +1,9 @@
 use anyhow::Context;
 use scraper::Selector;
 use std::collections::{HashMap, VecDeque};
+use titles::KEVIN_BACON;
 
 const GET_HTML_URL: &str = "https://en.wikipedia.org/api/rest_v1/page/html";
-pub const KEVIN_BACON_TITLE: &str = "Kevin_Bacon";
 // The returned html links to other articles by relative paths to their title
 const ARTICLE_LINK_PREFIX: &str = "./";
 
@@ -26,8 +26,8 @@ impl WikipediaCrawler {
     /// This function errors if it fails to find a successful path after
     /// exhausting all found links.
     pub fn crawl(&mut self) -> anyhow::Result<Vec<String>> {
-        if self.start == KEVIN_BACON_TITLE {
-            return Ok(vec![KEVIN_BACON_TITLE.to_string()]);
+        if self.start == KEVIN_BACON {
+            return Ok(vec![KEVIN_BACON.to_string()]);
         }
 
         let mut queue = VecDeque::from([self.start.to_string()]);
@@ -53,7 +53,7 @@ impl WikipediaCrawler {
 
                 parents.insert(linked_title.to_string(), cur_title.to_string());
 
-                if linked_title == KEVIN_BACON_TITLE {
+                if linked_title == KEVIN_BACON {
                     let path = self.get_path(&parents)?;
                     return Ok(path);
                 }
@@ -95,7 +95,7 @@ impl WikipediaCrawler {
     }
 
     fn get_path(&self, parents: &HashMap<String, String>) -> anyhow::Result<Vec<String>> {
-        let mut path = vec![KEVIN_BACON_TITLE.to_string()];
+        let mut path = vec![KEVIN_BACON.to_string()];
 
         while let Some(last) = path.last() {
             if last == &self.start {

--- a/crawlers/crawler_rs/tests/test_crawler.rs
+++ b/crawlers/crawler_rs/tests/test_crawler.rs
@@ -1,43 +1,30 @@
-use crawler_rs::{WikipediaCrawler, KEVIN_BACON_TITLE};
-
-const FOOTLOOSE_TITLE: &str = "Footloose_(1984_film)";
-const HERBERT_ROSS_TITLE: &str = "Herbert_Ross";
-const FRIDAY_THE_13TH_TITLE: &str = "Friday_the_13th_(1980_film)";
-const CITY_ON_A_HILL: &str = "City_on_a_Hill_(TV_series)";
-const AMANDA_CLAYTON_TITLE: &str = "Amanda_Clayton";
-const THE_BET_TITLE: &str = "The_Bet_(2016_film)";
+use crawler_rs::WikipediaCrawler;
+use titles::{
+    AMANDA_CLAYTON, CITY_ON_A_HILL, FOOTLOOSE, FRIDAY_THE_13TH, HERBERT_ROSS, KEVIN_BACON, THE_BET,
+};
 
 #[test]
 fn starting_at_kevin_bacon() {
-    let mut crawler = WikipediaCrawler::new(KEVIN_BACON_TITLE);
-    assert_eq!(crawler.crawl().unwrap(), vec![KEVIN_BACON_TITLE]);
+    let mut crawler = WikipediaCrawler::new(KEVIN_BACON);
+    assert_eq!(crawler.crawl().unwrap(), vec![KEVIN_BACON]);
 }
 
 #[test]
 fn one_hop_1() {
-    let mut crawler = WikipediaCrawler::new(FOOTLOOSE_TITLE);
-    assert_eq!(
-        crawler.crawl().unwrap(),
-        vec![FOOTLOOSE_TITLE, KEVIN_BACON_TITLE]
-    );
+    let mut crawler = WikipediaCrawler::new(FOOTLOOSE);
+    assert_eq!(crawler.crawl().unwrap(), vec![FOOTLOOSE, KEVIN_BACON]);
 }
 
 #[test]
 fn one_hop_2() {
-    let mut crawler = WikipediaCrawler::new(FRIDAY_THE_13TH_TITLE);
-    assert_eq!(
-        crawler.crawl().unwrap(),
-        vec![FRIDAY_THE_13TH_TITLE, KEVIN_BACON_TITLE]
-    );
+    let mut crawler = WikipediaCrawler::new(FRIDAY_THE_13TH);
+    assert_eq!(crawler.crawl().unwrap(), vec![FRIDAY_THE_13TH, KEVIN_BACON]);
 }
 
 #[test]
 fn one_hop_3() {
     let mut crawler = WikipediaCrawler::new(CITY_ON_A_HILL);
-    assert_eq!(
-        crawler.crawl().unwrap(),
-        vec![CITY_ON_A_HILL, KEVIN_BACON_TITLE]
-    );
+    assert_eq!(crawler.crawl().unwrap(), vec![CITY_ON_A_HILL, KEVIN_BACON]);
 }
 
 #[ignore = "long execution time"]
@@ -45,22 +32,22 @@ fn one_hop_3() {
 fn two_hops_1() {
     // Runs in about 5-60 seconds
     // Multiple paths with two hops
-    let mut crawler = WikipediaCrawler::new(HERBERT_ROSS_TITLE);
+    let mut crawler = WikipediaCrawler::new(HERBERT_ROSS);
     let result = crawler.crawl().unwrap();
 
     assert_eq!(result.len(), 3);
-    assert_eq!(result.first().unwrap(), HERBERT_ROSS_TITLE);
-    assert_eq!(result.last().unwrap(), KEVIN_BACON_TITLE);
+    assert_eq!(result.first().unwrap(), HERBERT_ROSS);
+    assert_eq!(result.last().unwrap(), KEVIN_BACON);
 }
 
 #[ignore = "long execution time"]
 #[test]
 fn two_hops_2() {
     // Runs in about 5-20 seconds
-    let mut crawler = WikipediaCrawler::new(AMANDA_CLAYTON_TITLE);
+    let mut crawler = WikipediaCrawler::new(AMANDA_CLAYTON);
     assert_eq!(
         crawler.crawl().unwrap(),
-        vec![AMANDA_CLAYTON_TITLE, CITY_ON_A_HILL, KEVIN_BACON_TITLE]
+        vec![AMANDA_CLAYTON, CITY_ON_A_HILL, KEVIN_BACON]
     );
 }
 
@@ -68,12 +55,12 @@ fn two_hops_2() {
 #[test]
 fn three_hops() {
     // Runs in about 1-7 minutes
-    let mut crawler = WikipediaCrawler::new(THE_BET_TITLE);
+    let mut crawler = WikipediaCrawler::new(THE_BET);
     let result = crawler.crawl().unwrap();
 
     assert_eq!(result.len(), 4);
-    assert_eq!(result.first().unwrap(), THE_BET_TITLE);
-    assert_eq!(result.last().unwrap(), KEVIN_BACON_TITLE);
+    assert_eq!(result.first().unwrap(), THE_BET);
+    assert_eq!(result.last().unwrap(), KEVIN_BACON);
 }
 
 #[test]

--- a/titles/Cargo.toml
+++ b/titles/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "titles"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+path = "titles.rs"

--- a/titles/generate_titles.py
+++ b/titles/generate_titles.py
@@ -1,0 +1,34 @@
+"""
+Usage:
+
+`python titles/generate_titles.py`
+
+- Execute after modifying `titles.json`
+- Creates `titles/titles.py` and `titles/titles.rs` files
+- Then, import created files from python or rust project files
+"""
+
+import json
+from pathlib import Path
+
+DATA_PATH = Path("titles/titles.json")
+OUT_PY = Path("titles/titles.py")
+OUT_RS = Path("titles/titles.rs")
+
+data = json.loads(DATA_PATH.read_text(encoding="utf8"))
+
+# generate Python constants
+py_lines = ["# GENERATED FILE — do not edit\n"]
+for key, title in data.items():
+    const = key.upper()
+    py_lines.append(f"{const} = {json.dumps(title)}")
+OUT_PY.write_text("\n".join(py_lines) + "\n", encoding="utf8")
+
+# generate Rust constants
+rs_lines = ["// GENERATED FILE — do not edit\n"]
+for key, title in data.items():
+    const = key.upper()
+    rs_lines.append(f"pub const {const}: &str = {json.dumps(title)};")
+OUT_RS.write_text("\n".join(rs_lines) + "\n", encoding="utf8")
+
+print("Generated", OUT_PY, "and", OUT_RS)

--- a/titles/titles.json
+++ b/titles/titles.json
@@ -1,0 +1,9 @@
+{
+  "kevin_bacon": "Kevin Bacon",
+  "footloose": "Footloose",
+  "herbert_ross": "Herbert Ross",
+  "friday_the_13th": "Friday the 13th (1980 film)",
+  "city_on_a_hill": "City on a Hill (TV series)",
+  "amanda_clayton": "Amanda Clayton",
+  "the_bet": "The Bet (2016 film)"
+}

--- a/titles/titles.py
+++ b/titles/titles.py
@@ -1,0 +1,9 @@
+# GENERATED FILE — do not edit
+
+KEVIN_BACON = "Kevin Bacon"
+FOOTLOOSE = "Footloose"
+HERBERT_ROSS = "Herbert Ross"
+FRIDAY_THE_13TH = "Friday the 13th (1980 film)"
+CITY_ON_A_HILL = "City on a Hill (TV series)"
+AMANDA_CLAYTON = "Amanda Clayton"
+THE_BET = "The Bet (2016 film)"

--- a/titles/titles.rs
+++ b/titles/titles.rs
@@ -1,0 +1,9 @@
+// GENERATED FILE — do not edit
+
+pub const KEVIN_BACON: &str = "Kevin Bacon";
+pub const FOOTLOOSE: &str = "Footloose";
+pub const HERBERT_ROSS: &str = "Herbert Ross";
+pub const FRIDAY_THE_13TH: &str = "Friday the 13th (1980 film)";
+pub const CITY_ON_A_HILL: &str = "City on a Hill (TV series)";
+pub const AMANDA_CLAYTON: &str = "Amanda Clayton";
+pub const THE_BET: &str = "The Bet (2016 film)";


### PR DESCRIPTION
Instead of copying the title string for articles needed, use a single json file containing these titles.

Create a script that generates python and rust code files with the titles as constants, and import these constants in code files as needed.